### PR TITLE
Update InvalidateCacheOutputAttribute.cs

### DIFF
--- a/AspNetCore.CacheOutput/InvalidateCacheOutputAttribute.cs
+++ b/AspNetCore.CacheOutput/InvalidateCacheOutputAttribute.cs
@@ -32,12 +32,12 @@ namespace AspNetCore.CacheOutput
             await base.OnResultExecutionAsync(context, next);
 
 #if NETCOREAPP2_0 || NETCOREAPP2_1
-            var isCacheable = context.HttpContext.Response != null ? IsCacheable(context.HttpContext.Response.StatusCode) : true;
+            var isCacheable = IsCacheable(context.HttpContext.Response?.StatusCode);
 #else
             var result = context.Result as IStatusCodeActionResult;
-            var isCacheable = result == null || result.StatusCode == null ? 
-                IsCacheable(context.HttpContext.Response.StatusCode) :
-                IsCacheable(result.StatusCode.Value);
+            var isCacheable = result == null ? 
+                IsCacheable(context.HttpContext.Response?.StatusCode) :
+                IsCacheable(result.StatusCode);
 #endif
             if (!isCacheable)
             {
@@ -57,10 +57,11 @@ namespace AspNetCore.CacheOutput
             await cache.RemoveStartsWithAsync(baseCacheKey);
         }
 
-        private bool IsCacheable(int statusCode)
+        private bool IsCacheable(int? statusCode)
         {
-            return statusCode >= (int)HttpStatusCode.OK &&
-                   statusCode < (int)HttpStatusCode.Ambiguous;
+            return statusCode == null ||
+                   (statusCode >= (int)HttpStatusCode.OK &&
+                    statusCode < (int)HttpStatusCode.Ambiguous);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -217,6 +217,39 @@ public void Post(Team value)
 }
 ```
 
+If an error occurs that would prevent the resource from getting updated, return a non-Success status code to stop the invalidation:
+
+```csharp
+[InvalidateCacheOutput(nameof(Get)] // this will invalidate Get upon a successful request
+public void Put(Team value)
+{
+    try{
+      // do stuff that causes an error
+    }
+    catch (...specific error)
+    {
+       Response.StatusCode = (int)HttpStatusCode.BadRequest;  // Prevents clearing the cache for the controller(s)
+    }
+}
+```
+This works with `ActionResult`s as well:
+```csharp
+[InvalidateCacheOutput(nameof(Get)] // this will invalidate Get upon a successful request
+public ActionResult Put(Team value)
+{
+    try{
+      // do stuff that causes an error
+    }
+    catch (...specific error)
+    {
+       return BadRequest();  // Prevents clearing the cache for the controller(s)
+    }
+    return NoContent();
+}
+```
+Please note that the `Forbiden()` `ActionResult` does not have a StatusCode causing it to fall back to the Response.StatusCode usage. Since `ActionResult` values aren't
+merged into the `Response` until much later, the `Response.StatusCode` will be defaulted to 200 and cause the cache to be invalidated. Setting the `Response.StatusCode` 
+to 403 will cause it to behave as expected.
 
 Customizing the cache keys
 --------------------------


### PR DESCRIPTION
Overriding the `OnResultExecutionAsync` method allows us to use the StatusCode set through using the ActionResult methods, falling back to the original test when unavailable.