### PR TITLE
Migrate from Thread.CurrentPrincipal to HttpContext.User

### DIFF
--- a/AspNetCore.CacheOutput/CacheOutputAttribute.cs
+++ b/AspNetCore.CacheOutput/CacheOutputAttribute.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using AspNetCore.CacheOutput.Time;
 using Microsoft.AspNetCore.Http;
@@ -285,7 +284,7 @@ namespace AspNetCore.CacheOutput
 
         protected virtual bool IsCachingAllowed(FilterContext actionContext, bool anonymousOnly)
         {
-            if (anonymousOnly && (Thread.CurrentPrincipal?.Identity.IsAuthenticated ?? false))
+            if (anonymousOnly && (actionContext.HttpContext.User?.Identity.IsAuthenticated ?? false))
             {
                 return false;
             }


### PR DESCRIPTION
In ASP.Net Core by default ClaimsPrincipal.Current and Thread.CurrentPrincipal aren't set. Microsoft docs recommend using DI / HttpContext.User / ControllerBase.User / IHttpContextAccessor.

This implementation uses HttpContext.User to retrieve the authentication details

Link https://docs.microsoft.com/en-us/aspnet/core/migration/claimsprincipal-current?view=aspnetcore-3.1