### PR TITLE
Only copy stream and buffer response to memory when action is wrapped with [CacheOutput] attribute

### DIFF
--- a/AspNetCore.CacheOutput.InMemory/AspNetCore.CacheOutput.InMemory.csproj
+++ b/AspNetCore.CacheOutput.InMemory/AspNetCore.CacheOutput.InMemory.csproj
@@ -10,7 +10,7 @@
     <RepositoryType>GitHub</RepositoryType>
     <PackageTags>aspnet, core, netcore, cacheoutput, cacheprovider</PackageTags>
     <Description>InMemoryOutputCacheProvider for AspNetCore.CacheOutput package</Description>
-    <Version>2.0.0-pre1</Version>
+    <Version>2.0.2-pre1</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/AspNetCore.CacheOutput.Redis/AspNetCore.CacheOutput.Redis.csproj
+++ b/AspNetCore.CacheOutput.Redis/AspNetCore.CacheOutput.Redis.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/Iamcerba/AspNetCore.CacheOutput</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <PackageTags>aspnet, core, netcore, cacheoutput, cacheprovider</PackageTags>
-    <Version>2.0.0-pre1</Version>
+    <Version>2.0.2-pre1</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/AspNetCore.CacheOutput/AspNetCore.CacheOutput.csproj
+++ b/AspNetCore.CacheOutput/AspNetCore.CacheOutput.csproj
@@ -7,7 +7,7 @@
     <Authors>Alexander Shabunevich</Authors>
     <Description>ASP.NET Core port of Strathweb.CacheOutput library (https://github.com/filipw/Strathweb.CacheOutput)</Description>
     <PackageTags>aspnet, core, netcore, cacheoutput, cache</PackageTags>
-    <Version>2.0.0-pre1</Version>
+    <Version>2.0.2-pre1</Version>
     <PackageProjectUrl>https://github.com/Iamcerba/AspNetCore.CacheOutput</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Iamcerba/AspNetCore.CacheOutput</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>

--- a/AspNetCore.CacheOutput/CacheOutputAttribute.cs
+++ b/AspNetCore.CacheOutput/CacheOutputAttribute.cs
@@ -219,11 +219,15 @@ namespace AspNetCore.CacheOutput
                 )
             )
             {
+                await SwapMemoryStreamBackToResponseBody(context);
+
                 return;
             }
 
             if (!IsCachingAllowed(context, AnonymousOnly))
             {
+                await SwapMemoryStreamBackToResponseBody(context);
+
                 return;
             }
 

--- a/AspNetCore.CacheOutput/CacheOutputAttribute.cs
+++ b/AspNetCore.CacheOutput/CacheOutputAttribute.cs
@@ -245,36 +245,36 @@ namespace AspNetCore.CacheOutput
                         string contentType = context.HttpContext.Response.ContentType;
                         string etag = context.HttpContext.Response.Headers[HeaderNames.ETag];
 
-                        var memoryStream = context.HttpContext.Response.Body as MemoryStream;
+                        var stream = context.HttpContext.Response.Body;
 
-                        if (memoryStream != null)
-                        {
-                            byte[] content = memoryStream.ToArray();
+                        var memoryStream = new MemoryStream();
+                        await stream.CopyToAsync(memoryStream);
 
-                            await cache.AddAsync(baseKey, string.Empty, cacheTime.AbsoluteExpiration);
-                            await cache.AddAsync(cacheKey, content, cacheTime.AbsoluteExpiration, baseKey);
+                        byte[] content = memoryStream.ToArray();
 
-                            await cache.AddAsync(
-                                cacheKey + Constants.ContentTypeKey,
-                                contentType,
-                                cacheTime.AbsoluteExpiration,
-                                baseKey
-                            );
+                        await cache.AddAsync(baseKey, string.Empty, cacheTime.AbsoluteExpiration);
+                        await cache.AddAsync(cacheKey, content, cacheTime.AbsoluteExpiration, baseKey);
 
-                            await cache.AddAsync(
-                                cacheKey + Constants.EtagKey,
-                                etag,
-                                cacheTime.AbsoluteExpiration,
-                                baseKey
-                            );
+                        await cache.AddAsync(
+                            cacheKey + Constants.ContentTypeKey,
+                            contentType,
+                            cacheTime.AbsoluteExpiration,
+                            baseKey
+                        );
 
-                            await cache.AddAsync(
-                                cacheKey + Constants.LastModifiedKey,
-                                actionExecutionTimestamp.ToString(),
-                                cacheTime.AbsoluteExpiration,
-                                baseKey
-                            );
-                        }
+                        await cache.AddAsync(
+                            cacheKey + Constants.EtagKey,
+                            etag,
+                            cacheTime.AbsoluteExpiration,
+                            baseKey
+                        );
+
+                        await cache.AddAsync(
+                            cacheKey + Constants.LastModifiedKey,
+                            actionExecutionTimestamp.ToString(),
+                            cacheTime.AbsoluteExpiration,
+                            baseKey
+                        );
                     }
                 }
             }

--- a/AspNetCore.CacheOutput/CacheOutputMiddleware.cs
+++ b/AspNetCore.CacheOutput/CacheOutputMiddleware.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
 namespace AspNetCore.CacheOutput
@@ -10,30 +9,12 @@ namespace AspNetCore.CacheOutput
 
         public CacheOutputMiddleware(RequestDelegate next)
         {
-            this.Next = next;
+            Next = next;
         }
 
         public async Task Invoke(HttpContext context)
         {
-            Stream originalStream = context.Response.Body;
-
-            try
-            {
-                using (Stream stream = new MemoryStream())
-                {
-                    context.Response.Body = stream;
-
-                    await Next.Invoke(context);
-
-                    stream.Seek(0, SeekOrigin.Begin);
-
-                    await stream.CopyToAsync(originalStream);
-                }
-            }
-            finally
-            {
-                context.Response.Body = originalStream;
-            }
+            await Next.Invoke(context);
         }
     }
 }


### PR DESCRIPTION
This PR resolves an issue whereby using this middleware causes all responses to be buffered into memory before being handed off to Kestrel/IIS etc.

Aside from the performance and memory impact of doing this, it can cause serious side effects when you are trying to stream data to a client - e.g. large downloads, or when you are trying to proxy data, e.g. consume network stream from a HttpClient and copy that to the response without buffering into memory.

I left the app.UseCacheOutput() in although it actually has no effect - happy to remove, but I felt leaving it in would avoid complications for users. Maybe it is better to mark as Obsolete and remove it in a future release.

The CacheOutputAttribute performs the memory stream swap if the response is eligible for caching so that headers etc. can be written before the content starts getting streamed to the client.

Although there are many ways of streaming content to clients, generally it is done similar to this: https://stackoverflow.com/questions/61056100/stream-data-from-an-asp-net-core-3-1-endpoint-without-consuming-huge-amounts-of - in fact, it is this StackOverflow question that helped me locate the middleware that was causing an issue in my use case.

Anyway, open to discussion about it!