### PR TITLE
Resolves #21 whereby memorystream is not swapped back during exception

### DIFF
--- a/AspNetCore.CacheOutput.Demo.InMemory/AspNetCore.CacheOutput.Demo.InMemory.csproj
+++ b/AspNetCore.CacheOutput.Demo.InMemory/AspNetCore.CacheOutput.Demo.InMemory.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/AspNetCore.CacheOutput.Demo.InMemory/Controllers/WeatherForecastController.cs
+++ b/AspNetCore.CacheOutput.Demo.InMemory/Controllers/WeatherForecastController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using AspNetCore.CacheOutput.Demo.InMemory.Exceptions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
@@ -42,6 +43,15 @@ namespace AspNetCore.CacheOutput.Demo.InMemory.Controllers
                 Summary = Summaries[rng.Next(Summaries.Length)]
             })
             .ToArray();
+        }
+
+        [HttpGet("error")]
+        // Returns empty response on exception
+        // Without cache returns: {"status":2,"good":false,"log":"abc"}
+        [CacheOutput]
+        public IEnumerable<WeatherForecast> GetError()
+        {
+            throw new BusinessException("abc");
         }
     }
 }

--- a/AspNetCore.CacheOutput.Demo.InMemory/Exceptions/BuisnessException.cs
+++ b/AspNetCore.CacheOutput.Demo.InMemory/Exceptions/BuisnessException.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+
+namespace AspNetCore.CacheOutput.Demo.InMemory.Exceptions
+{
+    [Serializable]
+    public class BusinessException : Exception
+    {
+        //
+        // For guidelines regarding the creation of new exception types, see
+        //    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpgenref/html/cpconerrorraisinghandlingguidelines.asp
+        // and
+        //    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/dncscol/html/csharp07192001.asp
+        //
+
+        public BusinessException() { }
+        public BusinessException(string message) : base(message) { }
+        public BusinessException(string message, Exception inner) : base(message, inner) { }
+
+        protected BusinessException(
+            SerializationInfo info,
+            StreamingContext context) : base(info, context) { }
+    }
+}

--- a/AspNetCore.CacheOutput.Demo.InMemory/Filters/HandleApiExceptionAttribute.cs
+++ b/AspNetCore.CacheOutput.Demo.InMemory/Filters/HandleApiExceptionAttribute.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace AspNetCore.CacheOutput.Demo.InMemory.Filters
+{
+    public class HandleApiExceptionAttribute : ExceptionFilterAttribute
+    {
+        public override Task OnExceptionAsync(ExceptionContext context)
+        {
+            var exception = context.Exception;
+
+            var obj = new
+            {
+                Status = 2,
+                Good = false,
+                Log = exception.Message
+            };
+
+            context.Result = new JsonResult(obj);
+
+            context.ExceptionHandled = true;
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/AspNetCore.CacheOutput.Demo.InMemory/Program.cs
+++ b/AspNetCore.CacheOutput.Demo.InMemory/Program.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Security.Principal;
+using AspNetCore.CacheOutput.Demo.InMemory.Filters;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace AspNetCore.CacheOutput.Demo.InMemory
@@ -19,6 +21,14 @@ namespace AspNetCore.CacheOutput.Demo.InMemory
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
+                }).ConfigureServices((hostContext, services) =>
+                {
+
+                    services.AddMvc(options =>
+                    {
+                        options.Filters.Add(typeof(HandleApiExceptionAttribute));
+                    });
+
                 });
     }
 }


### PR DESCRIPTION
Resolves issues described in https://github.com/Iamcerba/AspNetCore.CacheOutput/issues/21

It isn't a complex fix - we just need to see if the action failed, if it does, we swap the memory stream back. Tested and confirmed it resolves the issue.

To be honest it would be good to add automated tests, but I added the test case given and tested manually.

All that is required is checking the result of `next()` delegate calls and swapping back MemoryStream if there is a failure in the pipeline as the OnResultExcecution won't fire in this circumstance:

https://github.com/Iamcerba/AspNetCore.CacheOutput/pull/22/files#diff-951f5d08d226b9550dc3e112f60d66d73081165fcea438f52bb9ad2df44516f8R133 and https://github.com/Iamcerba/AspNetCore.CacheOutput/pull/22/files#diff-951f5d08d226b9550dc3e112f60d66d73081165fcea438f52bb9ad2df44516f8R171