### PR TITLE
Adds a ClearAll method to empty the cache on the InMemory provider

### DIFF
--- a/AspNetCore.CacheOutput.InMemory/InMemoryCacheOutputProvider.cs
+++ b/AspNetCore.CacheOutput.InMemory/InMemoryCacheOutputProvider.cs
@@ -70,5 +70,10 @@ namespace AspNetCore.CacheOutput.InMemory
                 }
             }
         }
+
+        public async Task ClearAll()
+        {
+            Cache.Compact(1.0);
+        }
     }
 }


### PR DESCRIPTION
The `RemoveAsync` method works great for invalidating specific content, but for my application I need to be able to completely clear the memory cache without restarting the application. Since the `Cache` is `private static readonly` I have no way to access it directly, so for now I'm using reflection. I'm submitting this pull request with the idea that this functionality may be useful for others.