### PR TITLE
Add support for .NET 9

### DIFF
--- a/AspNetCore.CacheOutput.InMemory/AspNetCore.CacheOutput.InMemory.csproj
+++ b/AspNetCore.CacheOutput.InMemory/AspNetCore.CacheOutput.InMemory.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0;net9.0;</TargetFrameworks>
     <Authors>Alexander Shabunevich</Authors>
     <Company />
     <Copyright>Copyright © 2018 Alexander Shabunevich</Copyright>
@@ -31,7 +31,11 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.*" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1' Or $(TargetFramework) == 'net6.0' Or $(TargetFramework) == 'net7.0' Or $(TargetFramework) == 'net8.0'">
+  <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1' Or $(TargetFramework) == 'net6.0' Or $(TargetFramework) == 'net7.0' Or $(TargetFramework) == 'net8.0' Or $(TargetFramework) == 'net9.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
@@ -39,7 +43,7 @@
     <PackageReference Include="AspNetCore.CacheOutput" Version="2.*" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1' Or $(TargetFramework) == 'net6.0' Or $(TargetFramework) == 'net7.0' Or $(TargetFramework) == 'net8.0'">
+  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1' Or $(TargetFramework) == 'net6.0' Or $(TargetFramework) == 'net7.0' Or $(TargetFramework) == 'net8.0' Or $(TargetFramework) == 'net9.0'">
     <PackageReference Include="AspNetCore.CacheOutput" Version="3.*" />
   </ItemGroup>
 

--- a/AspNetCore.CacheOutput.Redis/AspNetCore.CacheOutput.Redis.csproj
+++ b/AspNetCore.CacheOutput.Redis/AspNetCore.CacheOutput.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0;net9.0;</TargetFrameworks>
     <Authors>Alexander Shabunevich</Authors>
     <Company />
     <Description>StackExchangeRedisOutputCacheProvider for AspNetCore.CacheOutput package</Description>
@@ -35,7 +35,11 @@
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.*" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1' Or $(TargetFramework) == 'net6.0' Or $(TargetFramework) == 'net7.0' Or $(TargetFramework) == 'net8.0'">
+  <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1' Or $(TargetFramework) == 'net6.0' Or $(TargetFramework) == 'net7.0' Or $(TargetFramework) == 'net8.0' Or $(TargetFramework) == 'net9.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
@@ -43,7 +47,7 @@
     <PackageReference Include="AspNetCore.CacheOutput" Version="2.*" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1' Or $(TargetFramework) == 'net6.0' Or $(TargetFramework) == 'net7.0' Or $(TargetFramework) == 'net8.0'">
+  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1' Or $(TargetFramework) == 'net6.0' Or $(TargetFramework) == 'net7.0' Or $(TargetFramework) == 'net8.0' Or $(TargetFramework) == 'net9.0'">
     <PackageReference Include="AspNetCore.CacheOutput" Version="3.*" />
   </ItemGroup>
 

--- a/AspNetCore.CacheOutput.Redis/Extensions/StackExchangeRedisExtensions.cs
+++ b/AspNetCore.CacheOutput.Redis/Extensions/StackExchangeRedisExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Jil;
 using StackExchange.Redis;
 
 namespace AspNetCore.CacheOutput.Redis.Extensions
@@ -16,12 +15,12 @@ namespace AspNetCore.CacheOutput.Redis.Extensions
                 return default(T);
             }
 
-            return JSON.Deserialize<T>(result);
+            return System.Text.Json.JsonSerializer.Deserialize<T>(result);
         }
 
         internal static Task<bool> SetAsync(this IDatabase cache, string key, object value, TimeSpan? expiry = null)
         {
-            return cache.StringSetAsync(key, JSON.Serialize(value), expiry);
+            return cache.StringSetAsync(key, System.Text.Json.JsonSerializer.Serialize(value), expiry);
         }
     }
 }

--- a/AspNetCore.CacheOutput/AspNetCore.CacheOutput.csproj
+++ b/AspNetCore.CacheOutput/AspNetCore.CacheOutput.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0;net9.0;</TargetFrameworks>
     <AssemblyName>AspNetCore.CacheOutput</AssemblyName>
     <Company />
     <Authors>Alexander Shabunevich</Authors>
@@ -16,7 +16,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1' Or $(TargetFramework) == 'net6.0' Or $(TargetFramework) == 'net7.0' Or $(TargetFramework) == 'net8.0'">
+  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1' Or $(TargetFramework) == 'net6.0' Or $(TargetFramework) == 'net7.0' Or $(TargetFramework) == 'net8.0' Or $(TargetFramework) == 'net9.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 


### PR DESCRIPTION
Note this will break any existing values stored in Redis, as the Jil JSON serialization is different from the System.Text.Json.JsonSerializer 

Jil doesn't work, as .NET 9 has a new overload for System.TimeSpan.From* that accepts integers. See: https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/9.0/timespan-from-overloads

I see there is an issue logged for this on [Jil Repo](https://github.com/kevin-montrose/Jil/issues/363)